### PR TITLE
Add missing request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@slack/client": "^3.5.3",
     "bluebird": "^3.3.4",
+    "request": "2.76.0",
     "sqlite3": "^3.1.9"
   }
 }


### PR DESCRIPTION
Bot is failing with:
```
Jan  9 11:07:27 dev-adeng sandbot: Error: Cannot find module 'request'
Jan  9 11:07:27 dev-adeng sandbot:     at Function.Module._resolveFilename (module.js:536:15)
Jan  9 11:07:27 dev-adeng sandbot:     at Function.Module._load (module.js:466:25)
Jan  9 11:07:27 dev-adeng sandbot:     at Module.require (module.js:579:17)
Jan  9 11:07:27 dev-adeng sandbot:     at require (internal/module.js:11:18)
Jan  9 11:07:27 dev-adeng sandbot:     at Object.<anonymous> (/usr/wikia/sandbot/index.js:4:15)
```
Let's add the missing dependency.