### PR TITLE
Add F2 sandboxes to the database

### DIFF
--- a/common.js
+++ b/common.js
@@ -2,7 +2,7 @@ const db = require('./db/connection');
 
 module.exports = {
   getSandboxNameFromMessage({ text }) {
-    const match = text.match(/((sandbox|adeng|neutron-api)-.*)/i);
+    const match = text.match(/((sandbox|adeng|neutron-api|f2)-.*)/i);
 
     if (match) {
       return match[0];

--- a/db/023_add_f2_sandboxes.js
+++ b/db/023_add_f2_sandboxes.js
@@ -1,0 +1,20 @@
+const db = require('./connection');
+const channels = require('../channels');
+
+db.serialize(() => {
+  db.run(`INSERT INTO sandboxes VALUES('f2-sandbox-1', '${channels.IWING_CHANNEL_ID}', '', null);`);
+  db.run(`INSERT INTO sandboxes VALUES('f2-sandbox-2', '${channels.IWING_CHANNEL_ID}', '', null);`);
+  db.run(`INSERT INTO sandboxes VALUES('f2-sandbox-3', '${channels.IWING_CHANNEL_ID}', '', null);`);
+  db.run(`INSERT INTO sandboxes VALUES('f2-sandbox-4', '${channels.IWING_CHANNEL_ID}', '', null);`);
+  db.run(`INSERT INTO sandboxes VALUES('f2-sandbox-5', '${channels.IWING_CHANNEL_ID}', '', null);`);
+  db.run(`INSERT INTO sandboxes VALUES('f2-sandbox-6', '${channels.IWING_CHANNEL_ID}', '', null);`);
+  db.run(`INSERT INTO sandboxes VALUES('f2-sandbox-7', '${channels.IWING_CHANNEL_ID}', '', null);`);
+  db.run(`INSERT INTO sandboxes VALUES('f2-sandbox-8', '${channels.IWING_CHANNEL_ID}', '', null);`);
+  db.run(`INSERT INTO sandboxes VALUES('f2-sandbox-fandom', '${channels.IWING_CHANNEL_ID}', '', null);`);
+  db.run(`INSERT INTO sandboxes VALUES('f2-sandbox-adeng', '${channels.IWING_CHANNEL_ID}', '', null);`);
+  db.run(`INSERT INTO sandboxes VALUES('f2-sandbox-qa', '${channels.IWING_CHANNEL_ID}', '', null);`);
+
+  console.log('F2 sandboxes added.');
+
+  db.close();
+});

--- a/messages/book.js
+++ b/messages/book.js
@@ -26,7 +26,7 @@ function bookSandbox(message) {
 }
 
 module.exports = {
-  pattern: /(biore|taking) (sandbox|adeng|neutron-api)-|^[bt] (sandbox|adeng|neutron-api)-/i,
+  pattern: /(biore|taking) (sandbox|adeng|neutron-api|f2)-|^[bt] (sandbox|adeng|neutron-api|f2)-/i,
   action({ message, say }) {
     const sandboxName = getSandboxNameFromMessage(message);
     let msg = `<@${message.user}> `;

--- a/messages/release.js
+++ b/messages/release.js
@@ -51,7 +51,7 @@ function releaseSandbox(message) {
 }
 
 module.exports = {
-  pattern: /(zwalniam|releasing) (sandbox|adeng|neutron-api)-|^[zr] (sandbox|adeng|neutron-api)-/i,
+  pattern: /(zwalniam|releasing) (sandbox|adeng|neutron-api|f2)-|^[zr] (sandbox|adeng|neutron-api|f2)-/i,
   action({ message, say }) {
     releaseSandbox(message)
       .then((data) => {


### PR DESCRIPTION
This pull request adds a new database migration script to populate the `sandboxes` table with several F2 sandbox environments, all associated with the `IWING_CHANNEL_ID` channel.

Database migration:

* Added `db/023_add_f2_sandboxes.js` to insert multiple F2 sandbox entries (e.g., `f2-sandbox-1` through `f2-sandbox-8`, `f2-sandbox-fandom`, `f2-sandbox-adeng`, and `f2-sandbox-qa`) into the `sandboxes` table, each linked to the `IWING_CHANNEL_ID` from the `channels` module.