### PR TITLE
feat: add sandbox-ctools5 and sandbox-ctools6 to database

### DIFF
--- a/db/024_add_ctools_sandboxes_5_6.js
+++ b/db/024_add_ctools_sandboxes_5_6.js
@@ -1,0 +1,11 @@
+const db = require('./connection');
+const channels = require('../channels');
+
+db.serialize(() => {
+  db.run(`INSERT INTO sandboxes VALUES('sandbox-ctools5', '${channels.CONSUMER_TOOLS_CHANNEL_ID}', '', null);`);
+  db.run(`INSERT INTO sandboxes VALUES('sandbox-ctools6', '${channels.CONSUMER_TOOLS_CHANNEL_ID}', '', null);`);
+
+  console.log('Added sandbox-ctools5 and sandbox-ctools6.');
+
+  db.close();
+});


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
  - Add `sandbox-ctools5` and `sandbox-ctools6` to DB via migration `024_add_ctools_sandboxes_5_6.js`                                                                                                                                                                                                                                                                                                                                                                                                 
  - Both use `CONSUMER_TOOLS_CHANNEL_ID`, matching existing ctools1-4 pattern                                                                                                                                                                                                                                                                                                                                                                                                                       
  - No regex changes needed — `sandbox-` prefix already covered 