### PR TITLE
security: add minimum release age (7 days)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=10080


### PR DESCRIPTION
Introduces a 7-day minimum release age gate to mitigate npm supply-chain attacks (preventing the installation of brand-new, potentially malicious packages).

As part of the initiative described [here](https://fandom.slack.com/archives/CJMK4EXLN/p1780299450713149), I am leaving this PR open for the repository maintainers to review, discuss, and decide on adoption.